### PR TITLE
Get rid of redundant wellness reminder

### DIFF
--- a/schedules/wellness_reminders.yml
+++ b/schedules/wellness_reminders.yml
@@ -14,7 +14,6 @@
       - Thursday
       - Sunday
     time: "18:00"
-- message: "#wellness_rem
 - message: "#wellness_reminder#"
   webhook: aspen_general
   schedule:


### PR DESCRIPTION
Pretend people were complain about two messages appearing at 2:30 on saturday. 